### PR TITLE
fix: referencia da temperatura no swagger

### DIFF
--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -44,8 +44,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Temperatura
-              "
+              $ref: "#/definitions/Temperatura"
         "400":
           description: "Bad Input Parameter"
 


### PR DESCRIPTION
Pequeno ajuste na definição do arquivo **swagger.json** para corrigir o erro abaixo, que ocorre ao expandir a requisição de conversão de Celsius para Farenheit.

![erro-swagger-definicao-temperatura](https://user-images.githubusercontent.com/31139370/150252152-2ffe3b9d-ce5f-433a-93d9-a77a34a010b9.PNG)
